### PR TITLE
Fix qrutil.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let img = qrcode.encodeString("https://makecode.com");
 
 ## Acknoledgment: QR code generator
 
-This library is a port of https://github.com/pelikhan/pxt-qrcode, fixed for the latest MakeCode environment.
+This library is a port of [https://github.com/pelikhan/pxt-qrcode](https://github.com/kazuhikoarase/qrcode-generator), fixed for the latest MakeCode environment.
 
 ## Supported targets
 * for PXT/arcade

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let img = qrcode.encodeString("https://makecode.com");
 
 ## Acknoledgment: QR code generator
 
-This library is a port of https://github.com/kazuhikoarase/qrcode-generator, optimized for the MakeCode environment.
+This library is a port of https://github.com/pelikhan/pxt-qrcode, fixed for the latest MakeCode environment.
 
 ## Supported targets
 * for PXT/arcade

--- a/qrutil.ts
+++ b/qrutil.ts
@@ -137,7 +137,7 @@ namespace qrcode {
     }
   
     private static isAlphaNum(s: string): boolean {
-      for (let i = 0; i < s.length(); i++) {
+      for (let i = 0; i < s.length; i++) {
         let c = s.charAt(i);
         if (!('0' <= c && c <= '9') && !('A' <= c && c <= 'Z') && " $%*+-./:".indexOf(c) == -1) {
           return false;


### PR DESCRIPTION
Fix urutil.ts. Before, it used <number>.length() instead of <number>.length. This has been fixed and it now runs in the latest makecode enviroment.